### PR TITLE
Fix getIlluminanceState function

### DIFF
--- a/remote/src/main/java/org/openbase/bco/dal/remote/service/IlluminanceStateServiceRemote.java
+++ b/remote/src/main/java/org/openbase/bco/dal/remote/service/IlluminanceStateServiceRemote.java
@@ -81,7 +81,8 @@ public class IlluminanceStateServiceRemote extends AbstractServiceRemote<Illumin
                 continue;
             }
 
-            averageIlluminance += Math.max(timestamp, service.getIlluminanceState().getTimestamp().getTime());
+            averageIlluminance += service.getIlluminanceState().getIlluminance();
+            timestamp = Math.max(timestamp, service.getIlluminanceState().getTimestamp().getTime());
         }
         averageIlluminance = averageIlluminance / amount;
 


### PR DESCRIPTION
Timestamp might not be suitable as a average illuminance 